### PR TITLE
kde: Fix program and icon name

### DIFF
--- a/kde/CMakeLists.txt
+++ b/kde/CMakeLists.txt
@@ -1,8 +1,3 @@
-if(NOT DEFINED DIGIDOC_EXECUTABLE)
-    set(DIGIDOC_EXECUTABLE qdigidocclient)
-    set(DIGIDOC_ICON qdigidoc-client)
-endif()
-
 configure_file(qdigidoc-signer.desktop.cmake qdigidoc-signer.desktop)
 
 set(SERVICES_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/kservices5" CACHE PATH "Install dir for KDE service (desktop, protocol, ...) files")

--- a/kde/qdigidoc-signer.desktop.cmake
+++ b/kde/qdigidoc-signer.desktop.cmake
@@ -13,5 +13,5 @@ X-KDE-PluginInfo-Version=1.0
 Name=Sign digitally
 Name[et]=Allkirjasta digitaalselt
 Name[ru]=Подписать дигитально
-Icon=${DIGIDOC_ICON}
-Exec=${DIGIDOC_EXECUTABLE} -sign %U
+Icon=qdigidoc4
+Exec=qdigidoc4 -sign %U


### PR DESCRIPTION
DigiDoc4-Client installs `qdigidoc4`, so adjust to unbreak its KDE
extension.

Since the CMake variables are only used once, simply hardcode them.
The nautlius extension already does it that way, using `qdigidoc4`.

Signed-off-by: Klemens Nanni <klemens@posteo.de>
